### PR TITLE
FIX: Pass client_* fields with request, rather than std Authorization

### DIFF
--- a/lib/apple_auth/token.rb
+++ b/lib/apple_auth/token.rb
@@ -71,7 +71,8 @@ module AppleAuth
       {
         site: APPLE_AUD,
         authorize_url: '/auth/authorize',
-        token_url: '/auth/token'
+        token_url: '/auth/token',
+        auth_scheme: :request_body
       }
     end
 


### PR DESCRIPTION
This fix is applied to resolve an 'invalid_client' response from Apple when validating user JWTs from a mobile app.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.
Thanks for contributing to this project! -->
